### PR TITLE
fix(country-data): update Brazil phone format

### DIFF
--- a/src/data/countryData.ts
+++ b/src/data/countryData.ts
@@ -52,7 +52,7 @@ export const defaultCountries: CountryData[] = [
   ['Bolivia', 'bo', '591'],
   ['Bosnia and Herzegovina', 'ba', '387'],
   ['Botswana', 'bw', '267'],
-  ['Brazil', 'br', '55', '(..) .........'],
+  ['Brazil', 'br', '55', '(..) .....-....'],
   ['British Indian Ocean Territory', 'io', '246'],
   ['Brunei', 'bn', '673'],
   ['Bulgaria', 'bg', '359'],


### PR DESCRIPTION
## What has been done

Updated Brazil phone with a hyphen

Also, I don't know how we would do this, but there is a diference between mobile and landlines

NSN length	10 digits (landlines)
11 digits (mobiles)
Format	AA NNNN-NNNN (landlines)
AA 9NNNN-NNNN (mobile lines)

Source: https://en.wikipedia.org/wiki/Telephone_numbers_in_Brazil?useskin=vector